### PR TITLE
英文封面Ph.D应为有衬线字体

### DIFF
--- a/nudtpaper.cls
+++ b/nudtpaper.cls
@@ -587,7 +587,7 @@
   {\bf \sanhao[1.5] %调整与word一致
 A dissertation\\
 Submitted in partial fulfillment of the requirements\\
-for the degree of \textsf{\@optionpaperclassen{} of \@enpapertype}\\
+for the degree of \@optionpaperclassen{} of \textsf{\@enpapertype}\\
 in \textsf{\@ensubject}\\
 \makebox[\textwidth]{\ifisanon{~}\else{Graduate School of National University of %
 Defense Technology}\fi}\\


### PR DESCRIPTION
将591行中  Ph.D of Engineering 全部为无衬线字体
for the degree of \textsf{\@optionpaperclassen{} of \@enpapertype}\\

按照word模板， 英文标题页中 Ph.D 为 有衬线字体，of Engineering 为无衬线字体，考虑到美观改为仅Engineering 为无衬线字体
for the degree of \@optionpaperclassen{} of \textsf{\@enpapertype}\\

若要考虑到和word模板完全一致，可以改为
for the degree of \@optionpaperclassen{} \textsf{of \@enpapertype}\\